### PR TITLE
v8 dependency for cpp-ethereum

### DIFF
--- a/cpp-ethereum.rb
+++ b/cpp-ethereum.rb
@@ -43,7 +43,7 @@ class CppEthereum < Formula
   depends_on 'gmp'
   depends_on 'curl'
   depends_on 'libjson-rpc-cpp'
-  depends_on 'v8'
+  depends_on 'v8-315'
 
   option 'with-gui', "Build with GUI (AlethZero)"
   option "with-evmjit", "Build with LLVM and enable EVMJIT"

--- a/cpp-ethereum.rb
+++ b/cpp-ethereum.rb
@@ -43,6 +43,7 @@ class CppEthereum < Formula
   depends_on 'gmp'
   depends_on 'curl'
   depends_on 'libjson-rpc-cpp'
+  depends_on 'v8'
 
   option 'with-gui', "Build with GUI (AlethZero)"
   option "with-evmjit", "Build with LLVM and enable EVMJIT"


### PR DESCRIPTION
added v8 to cpp ethereum dependencies.
It will be required once [#1763](https://github.com/ethereum/cpp-ethereum/issues/1763) will be finished.