### PR TITLE
Simplify geth install steps and remove dependencies

### DIFF
--- a/ethereum.rb
+++ b/ethereum.rb
@@ -26,9 +26,6 @@ class Ethereum < Formula
   end
 
   depends_on 'go' => :build
-  depends_on :hg
-  depends_on 'readline'
-  depends_on 'gmp'
 
   def install
     base = "src/github.com/ethereum/go-ethereum"

--- a/ethereum.rb
+++ b/ethereum.rb
@@ -28,40 +28,16 @@ class Ethereum < Formula
   depends_on 'go' => :build
 
   def install
-    base = "src/github.com/ethereum/go-ethereum"
-
-    ENV["GOPATH"] = "#{buildpath}/#{base}/Godeps/_workspace:#{buildpath}"
     ENV["GOROOT"] = "#{HOMEBREW_PREFIX}/opt/go/libexec"
-    ENV["PATH"] = "#{ENV['GOPATH']}/bin:#{ENV['PATH']}"
-
-    # Debug env
-    system "go", "env"
-
-    # Move checked out source to base
-    mkdir_p base
-    Dir["**"].reject{ |f| f['src']}.each do |filename|
-      move filename, "#{base}/"
-    end
-
-    cmd = "#{base}/cmd/"
-
-    system "go", "build", "-v", "./#{cmd}evm"
-    system "go", "build", "-v", "./#{cmd}geth"
-    system "go", "build", "-v", "./#{cmd}disasm"
-    system "go", "build", "-v", "./#{cmd}rlpdump"
-    system "go", "build", "-v", "./#{cmd}ethtest"
-    system "go", "build", "-v", "./#{cmd}bootnode"
-
-    bin.install 'evm'
-    bin.install 'geth'
-    bin.install 'disasm'
-    bin.install 'rlpdump'
-    bin.install 'ethtest'
-    bin.install 'bootnode'
+    system "go", "env" # Debug env
+    system "make", "all"
+    bin.install 'build/bin/evm'
+    bin.install 'build/bin/geth'
+    bin.install 'build/bin/rlpdump'
   end
 
   test do
-    system "go", "test", "github.com/ethereum/go-ethereum/..."
+    system "make", "test"
   end
 
   def plist; <<-EOS.undent


### PR DESCRIPTION
As of version 1.3.4, both develop and master branch have no runtime dependencies and need only go to compile.

The install steps can be simplified to just run "make all" instead of copying the source around. This has the additional benefit that the git commit hash will be recorded into the binary.

Finally, I also removed some of the executables because they are mostly for internal use.