### PR TITLE
Renamed Mix.app to Mix-ide.app in homebrew cpp-ethereum tap

### DIFF
--- a/cpp-ethereum.rb
+++ b/cpp-ethereum.rb
@@ -80,7 +80,7 @@ class CppEthereum < Formula
 
     if build.with? "gui"
       prefix.install 'alethzero/alethzero/AlethZero.app'
-      prefix.install 'mix/Mix.app'
+      prefix.install 'mix/Mix-ide.app'
     end
   end
 


### PR DESCRIPTION
Fixes the following error
`Error: No such file or directory - mix/Mix.app`

when running 
`brew install cpp-ethereum --with-gui`