### PR TITLE
Added lines to the cpp-ethereum Homebrew formula for El Capitan binaries

### DIFF
--- a/cpp-ethereum.rb
+++ b/cpp-ethereum.rb
@@ -25,6 +25,7 @@ class CppEthereum < Formula
     revision 382
     root_url 'https://build.ethereum.org/cpp-binaries-data/brew_receipts'
     sha1 'bcce8b756b52df0b0dc9812a16f2744de89fc4f0' => :yosemite
+    sha1 'bcce8b756b52df0b0dc9812a16f2744de89fc4f0' => :el_capitan
   end
 
   devel do
@@ -32,6 +33,7 @@ class CppEthereum < Formula
       revision 382
       root_url 'https://build.ethereum.org/cpp-binaries-data/brew_receipts'
       sha1 'bcce8b756b52df0b0dc9812a16f2744de89fc4f0' => :yosemite
+      sha1 'bcce8b756b52df0b0dc9812a16f2744de89fc4f0' => :el_capitan
     end
 
     if build.include? "successful"


### PR DESCRIPTION
These are just cut-and-pastes of the Yosemite builds for this very first iteration.
And then the automation will take over, and make automatic in-place updates from there.

See https://github.com/ethereum/webthree-helpers/blob/develop/homebrew/prepare_receipt.sh#L58.