### PR TITLE
Update OS X Homebrew build to use llvm 3.8.

### DIFF
--- a/cpp-ethereum.rb
+++ b/cpp-ethereum.rb
@@ -59,7 +59,7 @@ class CppEthereum < Formula
   depends_on 'gmp'
   depends_on 'leveldb'
   depends_on 'libjson-rpc-cpp'
-  depends_on 'llvm37' if build.with? 'evmjit'
+  depends_on 'homebrew/versions/llvm38' if build.with? 'evmjit'
   depends_on 'miniupnpc'
   depends_on 'qt5' => ["with-d-bus"] if build.with? 'gui'
 


### PR DESCRIPTION
Also adding a full path.
A conversation I am having on Gitter indicates that the current formula MIGHT be broken, with an implicit dependency on the versions tap having previously been added, so might not work on a completely fresh machine.