### PR TITLE
Added explicit "homebrew/versions" for llvm37 dependency in C++ homebrew

### DIFF
--- a/cpp-ethereum.rb
+++ b/cpp-ethereum.rb
@@ -59,7 +59,7 @@ class CppEthereum < Formula
   depends_on 'gmp'
   depends_on 'leveldb'
   depends_on 'libjson-rpc-cpp'
-  depends_on 'llvm37' if build.with? 'evmjit'
+  depends_on 'homebrew/versions/llvm37' if build.with? 'evmjit'
   depends_on 'miniupnpc'
   depends_on 'qt5' => ["with-d-bus"] if build.with? 'gui'
 


### PR DESCRIPTION
…brew.

Without being explicit in this way, you can get brew install errors on a clean machine.