### PR TITLE
Fix SHAs for Yosemite homebrew.

### DIFF
--- a/cpp-ethereum.rb
+++ b/cpp-ethereum.rb
@@ -24,7 +24,7 @@ class CppEthereum < Formula
   bottle do
     revision 459
     root_url 'https://build.ethereum.org/cpp-binaries-data/brew_receipts'
-    sha1 'f1d23e339e26652514d8c717d83802151989d179' => :yosemite
+    sha1 '4af769442c770e901b16977f0cf899e49f184c96' => :yosemite
     sha1 '86833bfce725e50162d095c9986f77d3ad768598' => :el_capitan
   end
 
@@ -32,7 +32,7 @@ class CppEthereum < Formula
     bottle do
       revision 459
       root_url 'https://build.ethereum.org/cpp-binaries-data/brew_receipts'
-      sha1 'f1d23e339e26652514d8c717d83802151989d179' => :yosemite
+      sha1 '4af769442c770e901b16977f0cf899e49f184c96' => :yosemite
       sha1 '86833bfce725e50162d095c9986f77d3ad768598' => :el_capitan
     end
 


### PR DESCRIPTION
Looks like there is a sequencing issue with the two machines running in parallel.
I will create an issue to track that.