### PR TITLE
Add formula for solidity 0.3.6

### DIFF
--- a/solidity.rb
+++ b/solidity.rb
@@ -1,0 +1,34 @@
+#------------------------------------------------------------------------------
+# solidity.rb
+#
+# Homebrew formula for solidity.  Homebrew (http://brew.sh/) is
+# the de-facto standard package manager for OS X, and this Ruby script
+# contains the metadata used to map command-line user settings used
+# with the 'brew' command onto build options.
+#
+# Our documentation for the lsoidity Homebrew setup is at:
+#
+# http://solidity.readthedocs.io/en/latest/installing-solidity.html
+#
+# (c) 2014-2016 solidity contributors.
+#------------------------------------------------------------------------------
+
+class Solidity < Formula
+  desc "The Solidity Contract-Oriented Programming Language"
+  homepage "https://github.com/ethereum/solidity"
+  url "https://github.com/ethereum/solidity/archive/v0.3.6.tar.gz"
+  version "0.3.6"
+  sha256 "1947ce012ca540dc75495ebbb09b3b9ad1d48ffc076a51c7b2f18ca9870b5822"
+
+  depends_on "cmake" => :build
+  depends_on "boost" => "c++11"
+  depends_on "cryptopp"
+  depends_on "gmp"
+  depends_on "jsoncpp"
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+end


### PR DESCRIPTION
Given solidity is standalone now, I guess it needs its own formula! Took the dependencies from [the documentation](http://solidity.readthedocs.io/en/latest/installing-solidity.html), and it seems to work for me. Couldn't figure out how to get the tests to work though, which seem to assume the presence of `eth` in the source tree.

Took the header from `cpp-ethereum.rb` and changed it appropriately.

I was 50:50 on whether this should be `solc.rb`, but went with the repository name.