### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ bottles directly with `brew install <bottle_url>`, see [cpt-obvious](https://bui
 for previous builds.
 
 
-##Options
+## Options
 
 See `brew info ethereum` or `brew info cpp-ethereum` for all options. `--with-...` features are experimental patches.
 
@@ -126,7 +126,7 @@ Option                 | desc.
 
 **Note:** `--with-evmjit` requires LLVM to be installed with `brew install llvm --HEAD --with-clang`
 
-##Troubleshooting
+## Troubleshooting
 
 * Use `--verbose` to get more info while installing.
 * Make sure to update XCode and the command line tools.
@@ -138,7 +138,7 @@ Option                 | desc.
 * Take a walk
 
 
-##Patching
+## Patching
 
 First `cd /Library/Caches/Homebrew/ethereum--git/` and make your changes. Then `git diff > shiny.patch`, copy/paste the content of your patch under `__END__` of `ethereum.rb` and replace the `def patches` block with:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
