### PR TITLE
Install all go-ethereum executables

### DIFF
--- a/ethereum.rb
+++ b/ethereum.rb
@@ -14,10 +14,15 @@ class Ethereum < Formula
     ENV["GOROOT"] = "#{HOMEBREW_PREFIX}/opt/go/libexec"
     system "go", "env" # Debug env
     system "make", "all"
+    bin.install 'build/bin/abigen'
+    bin.install 'build/bin/bootnode'
     bin.install 'build/bin/evm'
+    bin.install 'build/bin/faucet'
     bin.install 'build/bin/geth'
-    bin.install 'build/bin/rlpdump'
     bin.install 'build/bin/puppeth'
+    bin.install 'build/bin/rlpdump'
+    bin.install 'build/bin/swarm'
+    bin.install 'build/bin/wnode'
   end
 
   test do


### PR DESCRIPTION
I had to build go-ethereum from source to use the `bootnode` executable. thought it would be easier to have `bootnode` installed by homebrew. also added the rest of the utils from `go-ethereum/build/bin`