### PR TITLE
Fix <<-EOS.undent deprecation

### DIFF
--- a/cpp-ethereum.rb
+++ b/cpp-ethereum.rb
@@ -68,7 +68,7 @@ class CppEthereum < Formula
 
   end
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">


### PR DESCRIPTION
Fixes #137.

Fixes the following error when installing:
```Warning: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/ethereum/homebrew-ethereum/ethereum.rb:49:in `plist'
Please report this to the ethereum/ethereum tap!
```
Info about this warning: Homebrew/brew#3319