### PR TITLE
Fix <<-EOS.undent deprecation warning in homebrew

### DIFF
--- a/ethereum.rb
+++ b/ethereum.rb
@@ -24,7 +24,7 @@ class Ethereum < Formula
     system "#{HOMEBREW_PREFIX}/bin/geth", "--version"
   end
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">


### PR DESCRIPTION
Fixes #137

`
Warning: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/ethereum/homebrew-ethereum/ethereum.rb:49:in `plist'
Please report this to the ethereum/ethereum tap!
`

The deprecation problem also seems to exist in the cpp-ethereum formula:
`
grep -irn --include=*.rb "EOS.undent" /usr/local/Homebrew/Library/Taps/ethereum
Throws:
/usr/local/Homebrew/Library/Taps/ethereum/homebrew-ethereum/ethereum.rb:27:  def plist; <<-EOS.undent
/usr/local/Homebrew/Library/Taps/ethereum/homebrew-ethereum/cpp-ethereum.rb:71:  def plist; <<-EOS.undent
`