### PR TITLE
Require el capitan for geth

### DIFF
--- a/ethereum.rb
+++ b/ethereum.rb
@@ -6,6 +6,9 @@ class Ethereum < Formula
     url 'https://github.com/ethereum/go-ethereum.git', :branch => 'master'
   end
 
+  # Is there a better way to ensure that frameworks (IOKit, CoreServices, etc) are installed?
+  depends_on :xcode => :build
+
   depends_on 'go' => :build
 
   def install

--- a/ethereum.rb
+++ b/ethereum.rb
@@ -6,6 +6,9 @@ class Ethereum < Formula
     url 'https://github.com/ethereum/go-ethereum.git', :branch => 'master'
   end
 
+  # Require El Capitan at least
+  depends_on :macos => :el_capitan
+
   # Is there a better way to ensure that frameworks (IOKit, CoreServices, etc) are installed?
   depends_on :xcode => :build
 


### PR DESCRIPTION
Fixes #117, #131 and #132.

I think this fixes the build problems - requires xcode (HID framework) and new macos.