### PR TITLE
Add desc to ethereum.rb

### DIFF
--- a/ethereum.rb
+++ b/ethereum.rb
@@ -1,4 +1,5 @@
 class Ethereum < Formula
+  desc "Official Go implementation of the Ethereum protocol"
   homepage 'https://github.com/ethereum/go-ethereum'
   url 'https://github.com/ethereum/go-ethereum.git', :tag => 'v1.8.12'
 


### PR DESCRIPTION
Fix "brew desc -s" problem:
```
$ brew desc -s colordiff
Error: undefined method `downcase' for nil:NilClass
Please report this bug:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/searchable.rb:14:in `simplify_string'
/usr/local/Homebrew/Library/Homebrew/searchable.rb:28:in `block (2 levels) in search_string'
/usr/local/Homebrew/Library/Homebrew/searchable.rb:28:in `any?'
/usr/local/Homebrew/Library/Homebrew/searchable.rb:28:in `block in search_string'
/usr/local/Homebrew/Library/Homebrew/searchable.rb:26:in `select'
/usr/local/Homebrew/Library/Homebrew/searchable.rb:26:in `search_string'
/usr/local/Homebrew/Library/Homebrew/searchable.rb:7:in `search'
/usr/local/Homebrew/Library/Homebrew/descriptions.rb:112:in `search'
/usr/local/Homebrew/Library/Homebrew/cmd/desc.rb:36:in `desc'
/usr/local/Homebrew/Library/Homebrew/brew.rb:100:in `<main>'
```