### PR TITLE
Add license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2018 ethereum, cpp-ethereum, and solidity contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -142,3 +142,7 @@ end
 ```
 
 If you want to submit your change, save your patch in a gist, add your `option 'shiny-option', 'Shiny description'` and the URL to your gist in the patches block and submit a pull request. Make sure to send a pull request to Ethereum also!
+
+## License
+
+[MIT](LICENSE.md) © 2014-2018 ethereum, cpp-ethereum, and solidity contributors

--- a/cpp-ethereum.rb
+++ b/cpp-ethereum.rb
@@ -10,7 +10,7 @@
 #
 # http://cpp-ethereum.org/installing-binaries/osx-homebrew.html
 #
-# (c) 2014-2017 cpp-ethereum contributors.
+# (c) 2014-2018 cpp-ethereum contributors.
 #------------------------------------------------------------------------------
 
 class CppEthereum < Formula

--- a/ethereum.rb
+++ b/ethereum.rb
@@ -1,3 +1,19 @@
+#------------------------------------------------------------------------------
+# ethereum.rb
+#
+# Homebrew formula for ethereum.  Homebrew (http://brew.sh/) is
+# the de-facto standard package manager for OS X, and this Ruby script
+# contains the metadata used to map command-line user settings used
+# with the 'brew' command onto build options.
+#
+# Our documentation for the ethereum Homebrew setup is at:
+#
+# https://github.com/ethereum/go-ethereum/wiki/Installation-Instructions-for-Mac#installing-with-homebrew
+#
+# (c) 2014-2018 ethereum contributors.
+#------------------------------------------------------------------------------
+
+
 class Ethereum < Formula
   homepage 'https://github.com/ethereum/go-ethereum'
   url 'https://github.com/ethereum/go-ethereum.git', :tag => 'v1.8.14'

--- a/solidity.rb
+++ b/solidity.rb
@@ -10,7 +10,7 @@
 #
 # http://solidity.readthedocs.io/en/latest/installing-solidity.html
 #
-# (c) 2014-2017 solidity contributors.
+# (c) 2014-2018 solidity contributors.
 #------------------------------------------------------------------------------
 
 class Solidity < Formula


### PR DESCRIPTION
This PR adds a license block to ethereum.rb, and adds an MIT license to the
repo in general.

Fixes #145.