### PR TITLE
[WIP] Begin homebrew version experiment

### DIFF
--- a/solidity@4.rb
+++ b/solidity@4.rb
@@ -13,15 +13,15 @@
 # (c) 2014-2017 solidity contributors.
 #------------------------------------------------------------------------------
 
-class SolidityAT52 < Formula
+class SolidityAT4 < Formula
   desc "The Solidity Contract-Oriented Programming Language"
   homepage "http://solidity.readthedocs.org"
-  url "https://github.com/ethereum/solidity/releases/download/v0.5.2/solidity_0.5.2.tar.gz"
-  version "0.5.2"
-  sha256 "95dd71f2e2ca2064bfcdc4104455f6cacb315dc29a27d5f6a7f7ef8eb0ec2ee7"
+  url "https://github.com/ethereum/solidity/releases/download/v0.4.25/solidity_0.4.25.tar.gz"
+  version "0.4.25"
+  sha256 "8172c126973eae1d9d6c7b5071910a9c7475ac64df3945f755cee66104add72d"
 
   depends_on "cmake" => :build
-  depends_on "boost" => "c++11"
+  depends_on "boost@1.60" => "c++11"
   # Note: due to a homebrew limitation, ccache will always be detected and cannot be turned off.
   depends_on "ccache" => :build
   depends_on "z3"

--- a/solidity@5.2.rb
+++ b/solidity@5.2.rb
@@ -1,0 +1,37 @@
+#------------------------------------------------------------------------------
+# solidity.rb
+#
+# Homebrew formula for solidity.  Homebrew (http://brew.sh/) is
+# the de-facto standard package manager for OS X, and this Ruby script
+# contains the metadata used to map command-line user settings used
+# with the 'brew' command onto build options.
+#
+# Our documentation for the solidity Homebrew setup is at:
+#
+# http://solidity.readthedocs.io/en/latest/installing-solidity.html
+#
+# (c) 2014-2017 solidity contributors.
+#------------------------------------------------------------------------------
+
+class SolidityAT52 < Formula
+  desc "The Solidity Contract-Oriented Programming Language"
+  homepage "http://solidity.readthedocs.org"
+  url "https://github.com/ethereum/solidity/releases/download/v0.5.2/solidity_0.5.2.tar.gz"
+  version "0.5.2"
+  sha256 "95dd71f2e2ca2064bfcdc4104455f6cacb315dc29a27d5f6a7f7ef8eb0ec2ee7"
+
+  depends_on "cmake" => :build
+  depends_on "boost" => "c++11"
+  # Note: due to a homebrew limitation, ccache will always be detected and cannot be turned off.
+  depends_on "ccache" => :build
+  depends_on "z3"
+
+  def install
+    system "cmake", ".", *std_cmake_args, "-DTESTS=OFF"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/solc", "--version"
+  end
+end


### PR DESCRIPTION
@erak and @chriseth I made a little experiment at supporting versions of formulae, so this works by installing (in this example):

```
brew install solidity
```

for latest version, and:

```
brew install solidity@5.2 # add .rb to test locally before it's published
```

for 5.2 etc. I got this working, but need to figure out how to alias `solc` etc to something like `solc52`, so you can specify the version, this is how Python versions does it with `pip` for example.

I can keep plugging at it, or we can link into the Github issues where people have asked for this feature and they can also help out :)