### PR TITLE
add version to cpp-ethereum tap and change odie to opoo

### DIFF
--- a/cpp-ethereum.rb
+++ b/cpp-ethereum.rb
@@ -16,8 +16,9 @@
 class CppEthereum < Formula
   desc "Ethereum C++ client"
   homepage "http://cpp-ethereum.org"
+  version "1.5.3"
 
   url "https://github.com/ethereum/aleth.git"
 
-  odie "Aleth (formerly cpp-ethereum) has been removed from Homebrew. Please install binary releases from https://github.com/ethereum/aleth/releases."
+  opoo "Aleth (formerly cpp-ethereum) has been removed from Homebrew. Please install binary releases from https://github.com/ethereum/aleth/releases."
 end


### PR DESCRIPTION
This PR is fixing the `cpp-ethereum` tap, which currently is breaking the whole `ethereum` tap. Fixes https://github.com/ethereum/go-ethereum/issues/19335.

Apparently `version` is a required parameter of taps in Homebrew, so I bumped up the previous patch version.

`odie` throws an error an exits the process gracefully, but this breaks `homebrew tap ethereum/ethereum`, therefore I've changed it to `opoo`, which only raises a warning:

```
$ brew tap nonsense/ethereum
==> Tapping nonsense/ethereum
Cloning into '/usr/local/Homebrew/Library/Taps/nonsense/homebrew-ethereum'...
remote: Enumerating objects: 9, done.
remote: Counting objects: 100% (9/9), done.
remote: Compressing objects: 100% (8/8), done.
remote: Total 9 (delta 2), reused 3 (delta 0), pack-reused 0
Unpacking objects: 100% (9/9), done.
Warning: Aleth (formerly cpp-ethereum) has been removed from Homebrew. Please install binary releases from https://github.com/ethereum/aleth/releases.
Tapped 4 formulae (38 files, 36.3KB).
```