### PR TITLE
fix(ruby): fix syntax for hash literals

### DIFF
--- a/ethereum.rb
+++ b/ethereum.rb
@@ -1,17 +1,17 @@
 class Ethereum < Formula
   desc "Official Go implementation of the Ethereum protocol"
   homepage "https://github.com/ethereum/go-ethereum"
-  url "https://github.com/ethereum/go-ethereum.git", :tag => "v1.10.1"
+  url "https://github.com/ethereum/go-ethereum.git", tag: "v1.10.1"
 
   head do
-    url "https://github.com/ethereum/go-ethereum.git", :branch => "master"
+    url "https://github.com/ethereum/go-ethereum.git", branch: "master"
   end
 
   # Require El Capitan at least
-  depends_on :macos => :el_capitan
+  depends_on macos: :el_capitan
 
   # Is there a better way to ensure that frameworks (IOKit, CoreServices, etc) are installed?
-  depends_on :xcode => :build
+  depends_on xcode: :build
 
   depends_on "go" => :build
 


### PR DESCRIPTION
This PR fixes outdated ruby syntax for ethereum.rb

Additionally, there are more fixes to be made, [you can see the output here](https://github.com/sambacha/homebrew-versions/runs/2202767535?check_suite_focus=true#step:5:18)

If replacing CircleCI with GitHub actions is OK, more than willing to implement these changes.

Thanks,

Sam