### PR TITLE
Bump xcode 14.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "11.4.0"
+      xcode: "14.2.0"
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
       - run:
           name: Install Solidity
           command: |
-            brew unlink python@2
             brew update
             brew upgrade
             #brew tap ethereum/ethereum # Acutally we should use the rule from the pull request

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
             brew upgrade
             #brew tap ethereum/ethereum # Acutally we should use the rule from the pull request
             brew install ./solidity.rb
+          no_output_timeout: 30m
 
       - run:
           name: Test Formula
@@ -33,6 +34,7 @@ jobs:
             brew update
             #brew tap ethereum/ethereum # Acutally we should use the rule from the pull request
             brew install ./solidity@7.rb
+          no_output_timeout: 30m
 
       - run:
           name: Test Formula
@@ -52,6 +54,7 @@ jobs:
             brew update
             #brew tap ethereum/ethereum # Acutally we should use the rule from the pull request
             brew install ./solidity@6.rb
+          no_output_timeout: 30m
 
       - run:
           name: Test Formula
@@ -71,6 +74,7 @@ jobs:
             brew update
             #brew tap ethereum/ethereum # Acutally we should use the rule from the pull request
             brew install ./solidity@5.rb
+          no_output_timeout: 30m
 
       - run:
           name: Test Formula
@@ -90,6 +94,7 @@ jobs:
             brew update
             #brew tap ethereum/ethereum # Acutally we should use the rule from the pull request
             brew install ./solidity@4.rb
+          no_output_timeout: 30m
 
       - run:
           name: Test Formula

--- a/solidity.rb
+++ b/solidity.rb
@@ -27,7 +27,7 @@ class Solidity < Formula
   depends_on "z3"
 
   def install
-    system "cmake", ".", *std_cmake_args, "-DTESTS=OFF"
+    system "cmake", ".", *std_cmake_args, "-DTESTS=OFF", "-DSTRICT_Z3_VERSION=OFF"
     system "make", "install"
   end
 


### PR DESCRIPTION
Fixes the building problems reported in the latest solidity version https://github.com/ethereum/homebrew-ethereum/pull/318#issuecomment-1412569246.

The PR updates `xcode` to `14.2.0` (and consequently `macos` version to `12.6`, see [circleci supported-xcode-versions](https://circleci.com/docs/using-macos/#supported-xcode-versions)), and change the brew formulae to use z3 `4.12.1`, since there is no formulae or casks for version `4.11.2` currently available (https://formulae.brew.sh/formula/z3).

I still need to check the compilation errors in the older solidity versions.