### PR TITLE
Puppeth was removed from Geth in January 2023.

### DIFF
--- a/ethereum.rb
+++ b/ethereum.rb
@@ -22,7 +22,6 @@ class Ethereum < Formula
     bin.install "build/bin/evm"
     bin.install "build/bin/geth"
     bin.install "build/bin/rlpdump"
-    bin.install "build/bin/puppeth"
   end
 
   test do


### PR DESCRIPTION
See: https://geth.ethereum.org/docs/tools/puppeth

And the install script need to be updated.