### PR TITLE
Update instructions for prioritizing latest keg

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ for previous builds.
 * Reinstall with `brew reinstall ethereum.rb` (send a pull request!)
 * Take a walk
 
-Note that the `ethereum` keg exists in [`homebrew-core`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/ethereum.rb). It's not always up to date in `homebrew-core` and you might want to prioritise the version from this tap. To do this, you can pin this tap by running the following command:
+Note that the `ethereum` keg exists in [`homebrew-core`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/e/ethereum.rb). It's not always up to date in `homebrew-core` and you might want to prioritise the version from this tap. To do this, you can explicitly install the latest version running the following command:
 
 ```shell
-brew tap-pin ethereum/ethereum
+brew install ethereum/ethereum/ethereum
 ```
 
 ## Patching


### PR DESCRIPTION
`tap-pin` was deprecated in https://brew.sh/2019/04/04/homebrew-2.1.0/ and is no longer available. The official recommentation is to either install mentioning the tap explicitly, or to rename the formula in one place to no longer have the naming conflict.

Also fixed the link to the `homebrew-core` keg. They made subdirectories for the first letter of the formula at some point.